### PR TITLE
Improve logging across modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ Q: What are your business hours?
 A: We are open Monday through Friday from 9 AM to 6 PM EST.
 ```
 
+## Logging
+
+The application uses Python's ``logging`` module. Logs are printed to
+``stdout`` and grouped by category:
+
+- ``app.routes`` – API layer
+- ``app.rag`` – RAG services
+- ``app.parser`` – knowledge base loader
+- ``app.db`` – database operations
+
+The default log level is ``INFO`` but ``DEBUG`` messages are available for
+additional detail.
+
 ## AI Coding Assistant Usage
 
 This project was developed with assistance from GitHub Copilot, which helped with:

--- a/src/crud.py
+++ b/src/crud.py
@@ -1,21 +1,38 @@
 from sqlalchemy.orm import Session
+import logging
 from .models import Interaction
+
+logger = logging.getLogger("app.db")
 
 
 def log_interaction(db: Session, question: str, answer: str) -> Interaction:
     """Store a question-answer interaction in the database."""
-    rec = Interaction(question=question, answer=answer)
-    db.add(rec)
-    db.commit()
-    db.refresh(rec)
-    return rec
+    logger.debug("Logging interaction to database")
+    if not question or not answer:
+        logger.warning("Empty question or answer provided")
+    try:
+        rec = Interaction(question=question, answer=answer)
+        db.add(rec)
+        db.commit()
+        db.refresh(rec)
+        logger.info("Interaction stored with id %s", rec.id)
+        return rec
+    except Exception as exc:
+        db.rollback()
+        logger.error("Failed to log interaction: %s", exc)
+        raise
 
 
 def get_history(db: Session, limit: int = 10) -> list[Interaction]:
     """Retrieve the latest interactions from the database."""
-    return (
-        db.query(Interaction)
-          .order_by(Interaction.ts.desc())
-          .limit(limit)
-          .all()
-    )
+    logger.debug("Fetching last %d interactions", limit)
+    try:
+        return (
+            db.query(Interaction)
+              .order_by(Interaction.ts.desc())
+              .limit(limit)
+              .all()
+        )
+    except Exception as exc:
+        logger.error("Failed to fetch history: %s", exc)
+        raise

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,15 +1,23 @@
 import re
+import logging
 from langchain.schema import Document
+
+logger = logging.getLogger("app.parser")
 
 _QA_RE = re.compile(r"Q:\s*(.*?)\nA:\s*(.*?)(?:\n---|\Z)", re.S)
 
 def load_knowledge(path: str) -> list[Document]:
-    """
-    Load Q/A pairs from a text file and return list of Document objects.
-    """
-    with open(path, encoding="utf-8") as f:
-        raw = f.read()
+    """Load Q/A pairs from a text file."""
+    logger.debug("Loading knowledge base from %s", path)
+    try:
+        with open(path, encoding="utf-8") as f:
+            raw = f.read()
+    except Exception as exc:
+        logger.error("Failed to read knowledge base: %s", exc)
+        raise
+
     pairs = _QA_RE.findall(raw)
+    logger.info("Loaded %d Q&A pairs", len(pairs))
     return [
         Document(
             page_content=f"Q: {q.strip()}\nA: {a.strip()}",

--- a/src/rag.py
+++ b/src/rag.py
@@ -9,7 +9,7 @@ from langchain.schema import Document
 from typing import List
 import logging
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("app.rag")
 
 
 class FAQRAGService:
@@ -20,6 +20,7 @@ class FAQRAGService:
         Args:
             docs: List of Document objects containing Q&A pairs
         """
+        logger.debug("Setting up FAQRAGService with %d documents", len(docs))
         self.emb = OllamaEmbeddings(model="nomic-embed-text",
                                     base_url="http://localhost:11434")
         self.vdb = Chroma.from_documents(docs, self.emb,
@@ -58,6 +59,7 @@ class FAQRAGService:
         # LangChain processes the input dict during summarization
         question = inputs["query"] if isinstance(inputs, dict) else str(inputs)
         docs = self.retriever.invoke(question)
+        logger.debug("Retrieved %d documents for context", len(docs))
         return "\n\n".join(d.page_content for d in docs)
 
     def answer(self, question: str) -> str:
@@ -78,6 +80,7 @@ class ContextInjectionService:
         Args:
             docs: List of Document objects containing Q&A pairs
         """
+        logger.debug("Setting up ContextInjectionService with %d documents", len(docs))
         # Store all document content as a single context string
         self.full_context = "\n\n".join(doc.page_content for doc in docs)
         


### PR DESCRIPTION
## Summary
- add dedicated loggers for parser, database, RAG and routes
- add debug/info logs and error handling in parser and CRUD
- log initialization steps and service selection in API routes
- log retriever events in RAG services
- document logging categories in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687de701551c832283f2c90a355e294d