### PR TITLE
Fix DB fixture to autouse

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ A: Yes, we offer a 14-day free trial with $100 in platform credits.
     os.unlink(temp_path)
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def clean_database():
     """Clean database before each test."""
     # Drop all tables and recreate them


### PR DESCRIPTION
## Summary
- ensure the database is cleared for every test by turning on autouse for `clean_database`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_687e807a3ad083228022e9b20964678a