### PR TITLE
Add optional OpenAI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ This is handled by the `get_ollama_base_url()` function in `src/rag.py`.
 - Requires `OPENAI_API_KEY` environment variable.
 - When building the vector store with OpenAI embeddings, the service logs the
   estimated token usage and approximate cost.
+- Context injection also runs on OpenAI when this provider is selected.
 
 ## 🐳 Docker Optimization
 

--- a/README.md
+++ b/README.md
@@ -298,9 +298,13 @@ This is handled by the `get_ollama_base_url()` function in `src/rag.py`.
 - Ensemble weights: 60% semantic, 40% keyword
 
 **LLM Settings**:
-- Model: `mistral` 
+- Model: `mistral` (default)
 - Temperature: 0.3 (for consistent responses)
 - Embedding model: `nomic-embed-text`
+- Set `LLM_PROVIDER=openai` to use OpenAI models.
+- Requires `OPENAI_API_KEY` environment variable.
+- When building the vector store with OpenAI embeddings, the service logs the
+  estimated token usage and approximate cost.
 
 ## 🐳 Docker Optimization
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ pytest-asyncio
 langchain-community==0.2.16
 ollama
 rank-bm25
+openai
+langchain-openai==0.2.16
+tiktoken

--- a/src/openai_service.py
+++ b/src/openai_service.py
@@ -1,0 +1,80 @@
+import os
+import logging
+from typing import List
+
+try:
+    from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+except Exception:  # pragma: no cover - missing optional deps
+    ChatOpenAI = None
+    OpenAIEmbeddings = None
+from langchain_community.vectorstores import Chroma
+from langchain_community.retrievers import BM25Retriever
+from langchain.prompts import ChatPromptTemplate
+from langchain.schema.runnable import RunnablePassthrough
+from langchain.schema.output_parser import StrOutputParser
+from langchain.retrievers import EnsembleRetriever
+from langchain.schema import Document
+
+from .rag import FACTUAL_FAQ_PROMPT
+
+logger = logging.getLogger("app.openai")
+
+
+class OpenAIRAGService:
+    """RAG service using OpenAI models."""
+
+    def __init__(self, docs: List[Document]) -> None:
+        logger.debug("Setting up OpenAIRAGService with %d documents", len(docs))
+        if ChatOpenAI is None or OpenAIEmbeddings is None:
+            raise ImportError("langchain-openai package is required")
+
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError("OPENAI_API_KEY not set")
+
+        embed_model = os.getenv("OPENAI_EMBED_MODEL", "text-embedding-3-small")
+        chat_model = os.getenv("OPENAI_MODEL", "gpt-4.1-nano")
+
+        self.emb = OpenAIEmbeddings(model=embed_model, openai_api_key=api_key)
+        self._log_embedding_cost(docs, embed_model)
+        self.vdb = Chroma.from_documents(docs, self.emb, persist_directory="chroma_db")
+
+        bm25 = BM25Retriever.from_documents(docs, k=3)
+        sem = self.vdb.as_retriever(search_kwargs={"k": 3})
+        self.retriever = EnsembleRetriever(retrievers=[sem, bm25], weights=[0.6, 0.4])
+
+        prompt = ChatPromptTemplate.from_template(FACTUAL_FAQ_PROMPT)
+        llm = ChatOpenAI(model=chat_model, temperature=0.3, openai_api_key=api_key)
+
+        self.chain = (
+            {"context": self._ctx, "query": RunnablePassthrough()}
+            | prompt
+            | llm
+            | StrOutputParser()
+        )
+
+    def _ctx(self, inputs) -> str:
+        question = inputs["query"] if isinstance(inputs, dict) else str(inputs)
+        docs = self.retriever.invoke(question)
+        logger.debug("Retrieved %d documents for context", len(docs))
+        return "\n\n".join(d.page_content for d in docs)
+
+    def answer(self, question: str) -> str:
+        try:
+            return self.chain.invoke({"query": question})
+        except Exception as e:
+            logger.error(f"OpenAI RAG service failed: {e}")
+            return "I'm sorry, I'm having trouble processing your question right now."
+
+    def _log_embedding_cost(self, docs: List[Document], model: str) -> None:
+        try:
+            import tiktoken
+        except ImportError:  # pragma: no cover - runtime warning
+            logger.warning("tiktoken not installed; skipping cost estimation")
+            return
+
+        enc = tiktoken.encoding_for_model(model)
+        total_tokens = sum(len(enc.encode(d.page_content)) for d in docs)
+        cost_per_1k = float(os.getenv("OPENAI_EMBED_COST", "0.00002"))
+        est = total_tokens / 1000 * cost_per_1k
+        logger.info("Estimated embedding tokens: %d (~$%.4f)", total_tokens, est)

--- a/src/routes.py
+++ b/src/routes.py
@@ -6,7 +6,7 @@ from typing import Generator
 from .database import SessionLocal, Base, engine
 from .parser import load_knowledge
 from .rag import FAQRAGService, ContextInjectionService
-from .openai_service import OpenAIRAGService
+from .openai_service import OpenAIRAGService, OpenAIContextInjectionService
 from . import crud, schemas
 
 logger = logging.getLogger("app.routes")
@@ -23,11 +23,11 @@ provider = os.getenv("LLM_PROVIDER", "ollama").lower()
 if provider == "openai":
     logger.info("Using OpenAI backend")
     rag_service = OpenAIRAGService(_docs)
+    context_service = OpenAIContextInjectionService(_docs)
 else:
     logger.info("Using Ollama backend")
     rag_service = FAQRAGService(_docs)
-
-context_service = ContextInjectionService(_docs)
+    context_service = ContextInjectionService(_docs)
 
 router = APIRouter()
 

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 from src.rag import FAQRAGService, ContextInjectionService
+from src.openai_service import OpenAIRAGService
 from langchain.schema import Document
 
 
@@ -61,3 +62,20 @@ def test_context_injection_answer():
         
         result = service.answer("hello")
         assert result == "resp"
+
+
+def test_openai_rag_service_initialization(monkeypatch):
+    """OpenAIRAGService should initialize with provided documents."""
+    docs = [Document(page_content="Q: t\nA: a")]
+    with (
+        patch("src.openai_service.OpenAIEmbeddings"),
+        patch("src.openai_service.Chroma"),
+        patch("src.openai_service.BM25Retriever"),
+        patch("src.openai_service.ChatOpenAI"),
+        patch("src.openai_service.ChatPromptTemplate"),
+        patch("src.openai_service.EnsembleRetriever"),
+    ):
+        monkeypatch.setenv("OPENAI_API_KEY", "test")
+        service = OpenAIRAGService(docs)
+        assert service is not None
+

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock, patch
 from src.rag import FAQRAGService, ContextInjectionService
-from src.openai_service import OpenAIRAGService
+from src.openai_service import OpenAIRAGService, OpenAIContextInjectionService
 from langchain.schema import Document
 
 
@@ -77,5 +77,17 @@ def test_openai_rag_service_initialization(monkeypatch):
     ):
         monkeypatch.setenv("OPENAI_API_KEY", "test")
         service = OpenAIRAGService(docs)
+        assert service is not None
+
+
+def test_openai_context_injection_initialization(monkeypatch):
+    """OpenAIContextInjectionService should initialize with documents."""
+    docs = [Document(page_content="Q: t\nA: a")]
+    with (
+        patch("src.openai_service.ChatOpenAI"),
+        patch("src.openai_service.ChatPromptTemplate"),
+    ):
+        monkeypatch.setenv("OPENAI_API_KEY", "test")
+        service = OpenAIContextInjectionService(docs)
         assert service is not None
 


### PR DESCRIPTION
## Summary
- include OpenAI, langchain-openai and tiktoken dependencies
- implement `OpenAIRAGService` with token cost logging
- allow switching providers in `routes` with `LLM_PROVIDER` env
- document OpenAI option in README
- test OpenAI service initialization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_community')*

------
https://chatgpt.com/codex/tasks/task_e_687f446d3bb88322b7c84ce5791e1017